### PR TITLE
feat: implement plan mode matching Claude Code v2.1.88

### DIFF
--- a/crates/planning/Cargo.toml
+++ b/crates/planning/Cargo.toml
@@ -4,16 +4,11 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
-cisco-code-protocol = { path = "../protocol" }
-cisco-code-providers = { path = "../providers" }
-tokio.workspace = true
-serde.workspace = true
-serde_json.workspace = true
-tracing.workspace = true
 anyhow.workspace = true
-thiserror.workspace = true
-uuid.workspace = true
-# petgraph = "0.6"  # TODO: add when implementing DAG
+tracing.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/planning/src/lib.rs
+++ b/crates/planning/src/lib.rs
@@ -1,12 +1,17 @@
-//! cisco-code-planning: Plan mode (DEPRECATED for now).
+//! cisco-code-planning: Plan mode for the agent loop.
 //!
-//! Plan mode is deferred — use Claude Code's built-in plan mode instead.
-//! This crate is kept as a placeholder for future implementation if needed.
-//!
-//! The original design called for DAG-based task planning (from Astro-Assistant),
-//! but the simpler ReAct loop in the agent turn loop handles most use cases well.
+//! Matches Claude Code v2.1.88's plan mode architecture:
+//! - Plan mode is a permission mode variant (read-only, no code changes)
+//! - Plans stored as markdown files at `~/.cisco-code/plans/{slug}.md`
+//! - Slug is a random word-based identifier (adjective-noun-verb)
+//! - EnterPlanMode/ExitPlanMode are tools that transition modes
+//! - PlanManager handles slug caching, file I/O, resume/fork
 
-// Placeholder structs kept for compilation; no active development.
+pub mod plan;
+pub mod manager;
 
-pub struct TaskDag;
-pub struct Planner;
+pub use plan::{
+    PlanModeState, PlanSlugCache,
+    plan_file_path, read_plan, resolve_plans_directory, write_plan,
+};
+pub use manager::PlanManager;

--- a/crates/planning/src/manager.rs
+++ b/crates/planning/src/manager.rs
@@ -1,0 +1,361 @@
+//! PlanManager — orchestrates plan mode lifecycle.
+//!
+//! Matches Claude Code v2.1.88's plan management:
+//! - Slug cache per session
+//! - File-based plan storage
+//! - Resume/fork support (copy plan for new sessions)
+//! - Plans directory resolution with path traversal defense
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::plan::{
+    plan_file_path, read_plan, resolve_plans_directory, write_plan,
+    PlanModeState, PlanSlugCache,
+};
+
+/// Manages plan mode lifecycle for a session.
+///
+/// The PlanManager is the single authority for:
+/// - Where plans are stored (plans directory)
+/// - What slug maps to what session
+/// - Reading/writing plan content
+/// - Copying plans across sessions (resume/fork)
+pub struct PlanManager {
+    /// Thread-safe slug cache shared across the runtime.
+    slug_cache: Arc<PlanSlugCache>,
+    /// Resolved plans directory path.
+    plans_dir: PathBuf,
+    /// Plan mode state (exit flags, pre-plan mode, etc.).
+    pub state: PlanModeState,
+}
+
+impl PlanManager {
+    /// Create a new PlanManager with default plans directory.
+    pub fn new() -> Self {
+        Self {
+            slug_cache: Arc::new(PlanSlugCache::new()),
+            plans_dir: resolve_plans_directory(None, None),
+            state: PlanModeState::default(),
+        }
+    }
+
+    /// Create a PlanManager with a custom plans directory.
+    pub fn with_plans_dir(
+        custom_dir: Option<&str>,
+        project_root: Option<&Path>,
+    ) -> Self {
+        Self {
+            slug_cache: Arc::new(PlanSlugCache::new()),
+            plans_dir: resolve_plans_directory(custom_dir, project_root),
+            state: PlanModeState::default(),
+        }
+    }
+
+    /// Create a PlanManager with a shared slug cache (for multi-session scenarios).
+    pub fn with_shared_cache(
+        slug_cache: Arc<PlanSlugCache>,
+        custom_dir: Option<&str>,
+        project_root: Option<&Path>,
+    ) -> Self {
+        Self {
+            slug_cache,
+            plans_dir: resolve_plans_directory(custom_dir, project_root),
+            state: PlanModeState::default(),
+        }
+    }
+
+    /// Get the plans directory path.
+    pub fn plans_dir(&self) -> &Path {
+        &self.plans_dir
+    }
+
+    /// Get the plan slug for a session, creating one if needed.
+    pub fn get_plan_slug(&self, session_id: &str) -> String {
+        self.slug_cache.get_or_create(session_id, &self.plans_dir)
+    }
+
+    /// Get the plan slug without creating one. Returns None if no slug exists.
+    pub fn get_plan_slug_if_exists(&self, session_id: &str) -> Option<String> {
+        self.slug_cache.get(session_id)
+    }
+
+    /// Set a specific slug for a session (used during resume).
+    pub fn set_plan_slug(&self, session_id: &str, slug: &str) {
+        self.slug_cache.set(session_id, slug);
+    }
+
+    /// Clear the slug for a session.
+    pub fn clear_plan_slug(&self, session_id: &str) {
+        self.slug_cache.clear(session_id);
+    }
+
+    /// Clear all cached slugs.
+    pub fn clear_all_slugs(&self) {
+        self.slug_cache.clear_all();
+    }
+
+    /// Get the plan file path for a session.
+    pub fn get_plan_file_path(
+        &self,
+        session_id: &str,
+        agent_id: Option<&str>,
+    ) -> PathBuf {
+        let slug = self.get_plan_slug(session_id);
+        plan_file_path(&self.plans_dir, &slug, agent_id)
+    }
+
+    /// Read the plan for a session from disk.
+    pub fn get_plan(
+        &self,
+        session_id: &str,
+        agent_id: Option<&str>,
+    ) -> Option<String> {
+        let slug = self.slug_cache.get(session_id)?;
+        read_plan(&self.plans_dir, &slug, agent_id)
+    }
+
+    /// Write a plan to disk for a session.
+    pub fn save_plan(
+        &self,
+        session_id: &str,
+        content: &str,
+        agent_id: Option<&str>,
+    ) -> Result<PathBuf> {
+        let slug = self.get_plan_slug(session_id);
+        write_plan(&self.plans_dir, &slug, content, agent_id)
+    }
+
+    /// Copy a plan from one session to another (for resume).
+    ///
+    /// Matches Claude Code's `copyPlanForResume`:
+    /// - Sets the target session's slug from the source
+    /// - Reads the plan file directly
+    /// - Returns the plan content if found
+    pub fn copy_plan_for_resume(
+        &self,
+        source_session_id: &str,
+        target_session_id: &str,
+    ) -> Option<String> {
+        let source_slug = self.slug_cache.get(source_session_id)?;
+        // Set the same slug for the target session
+        self.slug_cache.set(target_session_id, &source_slug);
+        // Read the plan (it's the same file)
+        read_plan(&self.plans_dir, &source_slug, None)
+    }
+
+    /// Fork a plan for a parallel session.
+    ///
+    /// Matches Claude Code's `copyPlanForFork`:
+    /// - Reads the original plan
+    /// - Generates a NEW slug for the forked session
+    /// - Writes the plan content to the new file
+    pub fn copy_plan_for_fork(
+        &self,
+        source_session_id: &str,
+        target_session_id: &str,
+    ) -> Result<Option<String>> {
+        let source_slug = match self.slug_cache.get(source_session_id) {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+
+        let content = match read_plan(&self.plans_dir, &source_slug, None) {
+            Some(c) => c,
+            None => return Ok(None),
+        };
+
+        // Generate a new slug for the forked session (don't reuse the original)
+        let new_slug = self.get_plan_slug(target_session_id);
+        write_plan(&self.plans_dir, &new_slug, &content, None)?;
+
+        Ok(Some(content))
+    }
+
+    /// Enter plan mode: record the current permission mode as pre_plan_mode.
+    pub fn enter_plan_mode(&mut self, current_mode: &str) {
+        self.state.pre_plan_mode = Some(current_mode.to_string());
+    }
+
+    /// Exit plan mode: restore the pre-plan permission mode.
+    ///
+    /// Returns the mode to restore to, or "default" if unknown.
+    pub fn exit_plan_mode(&mut self) -> String {
+        let restore_to = self
+            .state
+            .pre_plan_mode
+            .take()
+            .unwrap_or_else(|| "default".to_string());
+        self.state.handle_transition("plan", &restore_to);
+        restore_to
+    }
+
+    /// Check if plan mode has been exited this session.
+    pub fn has_exited_plan_mode(&self) -> bool {
+        self.state.has_exited_plan_mode
+    }
+
+    /// Take the exit attachment flag (returns true once after exiting plan mode).
+    pub fn take_exit_attachment(&mut self) -> bool {
+        self.state.take_exit_attachment()
+    }
+}
+
+impl Default for PlanManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manager_in_temp() -> (PlanManager, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let manager = PlanManager {
+            slug_cache: Arc::new(PlanSlugCache::new()),
+            plans_dir: dir.path().to_path_buf(),
+            state: PlanModeState::default(),
+        };
+        (manager, dir)
+    }
+
+    #[test]
+    fn test_plan_manager_new() {
+        let manager = PlanManager::new();
+        assert!(manager.plans_dir().to_string_lossy().contains("plans"));
+    }
+
+    #[test]
+    fn test_get_plan_slug_creates_and_caches() {
+        let (manager, _dir) = manager_in_temp();
+        let slug1 = manager.get_plan_slug("sess-1");
+        let slug2 = manager.get_plan_slug("sess-1");
+        assert_eq!(slug1, slug2);
+        assert!(!slug1.is_empty());
+    }
+
+    #[test]
+    fn test_get_plan_slug_if_exists() {
+        let (manager, _dir) = manager_in_temp();
+        assert!(manager.get_plan_slug_if_exists("sess-1").is_none());
+        manager.get_plan_slug("sess-1");
+        assert!(manager.get_plan_slug_if_exists("sess-1").is_some());
+    }
+
+    #[test]
+    fn test_set_and_clear_slug() {
+        let (manager, _dir) = manager_in_temp();
+        manager.set_plan_slug("sess-1", "my-custom-slug");
+        assert_eq!(
+            manager.get_plan_slug_if_exists("sess-1").unwrap(),
+            "my-custom-slug"
+        );
+        manager.clear_plan_slug("sess-1");
+        assert!(manager.get_plan_slug_if_exists("sess-1").is_none());
+    }
+
+    #[test]
+    fn test_save_and_get_plan() {
+        let (manager, _dir) = manager_in_temp();
+        let content = "## My Plan\n\n1. Do things\n";
+        manager.save_plan("sess-1", content, None).unwrap();
+
+        let read_back = manager.get_plan("sess-1", None).unwrap();
+        assert_eq!(read_back, content);
+    }
+
+    #[test]
+    fn test_get_plan_no_slug() {
+        let (manager, _dir) = manager_in_temp();
+        assert!(manager.get_plan("nonexistent", None).is_none());
+    }
+
+    #[test]
+    fn test_get_plan_file_path() {
+        let (manager, _dir) = manager_in_temp();
+        let path = manager.get_plan_file_path("sess-1", None);
+        assert!(path.to_string_lossy().ends_with(".md"));
+    }
+
+    #[test]
+    fn test_copy_plan_for_resume() {
+        let (manager, _dir) = manager_in_temp();
+        manager.save_plan("source", "Resume plan content", None).unwrap();
+
+        let content = manager.copy_plan_for_resume("source", "target");
+        assert_eq!(content.unwrap(), "Resume plan content");
+
+        // Target should now share the same slug
+        assert_eq!(
+            manager.get_plan_slug_if_exists("target").unwrap(),
+            manager.get_plan_slug_if_exists("source").unwrap()
+        );
+    }
+
+    #[test]
+    fn test_copy_plan_for_fork() {
+        let (manager, _dir) = manager_in_temp();
+        manager.save_plan("source", "Fork plan content", None).unwrap();
+
+        let content = manager.copy_plan_for_fork("source", "forked").unwrap();
+        assert_eq!(content.unwrap(), "Fork plan content");
+
+        // Forked should have a DIFFERENT slug
+        assert_ne!(
+            manager.get_plan_slug_if_exists("forked").unwrap(),
+            manager.get_plan_slug_if_exists("source").unwrap()
+        );
+
+        // But same content
+        assert_eq!(
+            manager.get_plan("forked", None).unwrap(),
+            "Fork plan content"
+        );
+    }
+
+    #[test]
+    fn test_copy_plan_for_fork_no_source() {
+        let (manager, _dir) = manager_in_temp();
+        let result = manager.copy_plan_for_fork("nonexistent", "target").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_enter_exit_plan_mode() {
+        let (mut manager, _dir) = manager_in_temp();
+        assert!(!manager.has_exited_plan_mode());
+
+        manager.enter_plan_mode("accept_reads");
+        assert_eq!(
+            manager.state.pre_plan_mode.as_deref(),
+            Some("accept_reads")
+        );
+
+        let restored = manager.exit_plan_mode();
+        assert_eq!(restored, "accept_reads");
+        assert!(manager.has_exited_plan_mode());
+        assert!(manager.take_exit_attachment());
+        assert!(!manager.take_exit_attachment()); // consumed
+    }
+
+    #[test]
+    fn test_exit_plan_mode_no_pre_mode() {
+        let (mut manager, _dir) = manager_in_temp();
+        let restored = manager.exit_plan_mode();
+        assert_eq!(restored, "default");
+    }
+
+    #[test]
+    fn test_clear_all_slugs() {
+        let (manager, _dir) = manager_in_temp();
+        manager.get_plan_slug("a");
+        manager.get_plan_slug("b");
+        manager.clear_all_slugs();
+        assert!(manager.get_plan_slug_if_exists("a").is_none());
+        assert!(manager.get_plan_slug_if_exists("b").is_none());
+    }
+}

--- a/crates/planning/src/plan.rs
+++ b/crates/planning/src/plan.rs
@@ -1,0 +1,439 @@
+//! Plan data model and slug generation.
+//!
+//! Matches Claude Code v2.1.88's plan mode:
+//! - Plans stored as markdown files at `~/.cisco-code/plans/{slug}.md`
+//! - Slug is a random word-based identifier (adjective-noun-verb)
+//! - Plan file is read/written by EnterPlanMode/ExitPlanMode tools
+//! - Subagent plans use `{slug}-agent-{agent_id}.md`
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use anyhow::Result;
+
+/// Word lists for generating human-readable plan slugs.
+const ADJECTIVES: &[&str] = &[
+    "amber", "azure", "bold", "bright", "calm", "clear", "cool", "crisp",
+    "dark", "deep", "dry", "eager", "fair", "fast", "firm", "fond",
+    "glad", "gold", "green", "hale", "hashed", "iron", "jade", "keen",
+    "kind", "late", "lean", "light", "loud", "lucid", "mild", "neat",
+    "noble", "odd", "pale", "plain", "proud", "pure", "quick", "rare",
+    "raw", "rich", "ripe", "safe", "sharp", "shy", "sleek", "slim",
+    "smart", "soft", "solid", "stark", "steady", "still", "stout", "swift",
+    "tame", "taut", "thin", "true", "vivid", "warm", "wide", "wild",
+    "wise", "young", "zen",
+];
+
+const NOUNS: &[&str] = &[
+    "arch", "bark", "beam", "blade", "bolt", "brook", "cape", "cedar",
+    "cliff", "cloud", "coral", "crane", "creek", "crest", "dawn", "dew",
+    "drift", "dune", "elm", "fern", "field", "flint", "forge", "frost",
+    "gate", "glade", "grove", "hawk", "haze", "heath", "helm", "hill",
+    "jade", "lake", "leaf", "ledge", "loom", "marsh", "mist", "moss",
+    "nest", "oak", "opal", "orbit", "path", "peak", "pine", "plume",
+    "pond", "quartz", "rain", "reef", "ridge", "river", "rock", "root",
+    "sage", "sand", "shade", "shore", "slate", "snow", "spark", "spire",
+    "star", "stem", "stone", "storm", "stream", "thorn", "tide", "trail",
+    "vale", "vine", "wave", "wind", "wood", "zephyr",
+];
+
+const VERBS: &[&str] = &[
+    "bind", "bloom", "break", "build", "burn", "carve", "cast", "chase",
+    "claim", "climb", "craft", "cross", "dance", "dare", "dash", "dive",
+    "draft", "draw", "drift", "drive", "fade", "fall", "find", "flash",
+    "float", "flow", "fly", "fold", "forge", "form", "frame", "fuse",
+    "glow", "grasp", "grind", "grow", "guide", "hatch", "haul", "heal",
+    "hoist", "hunt", "knit", "launch", "lead", "leap", "lift", "link",
+    "march", "meld", "merge", "mold", "paint", "parse", "plant", "press",
+    "probe", "pull", "push", "quest", "raise", "reach", "reap", "ride",
+    "ring", "rise", "roam", "root", "run", "sail", "scan", "sculpt",
+    "seek", "shape", "shift", "shine", "soar", "solve", "spark", "spin",
+    "split", "spring", "stand", "steer", "stitch", "stride", "surge",
+    "sweep", "swing", "trace", "trade", "turn", "twist", "vault", "wake",
+    "walk", "weave", "weld", "wind", "write",
+];
+
+/// Generate a random slug in the format "adjective-noun-verb".
+///
+/// Uses a simple random approach based on timestamp + counter to avoid
+/// requiring the `rand` crate dependency.
+fn generate_slug() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos() as u64;
+    let count = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let seed = now.wrapping_add(count).wrapping_mul(6364136223846793005);
+
+    let adj_idx = (seed % ADJECTIVES.len() as u64) as usize;
+    let noun_idx = ((seed >> 16) % NOUNS.len() as u64) as usize;
+    let verb_idx = ((seed >> 32) % VERBS.len() as u64) as usize;
+
+    format!(
+        "{}-{}-{}",
+        ADJECTIVES[adj_idx], NOUNS[noun_idx], VERBS[verb_idx]
+    )
+}
+
+/// Plan mode state tracking.
+///
+/// Matches Claude Code's `state.ts` plan mode fields:
+/// - `has_exited_plan_mode`: whether user exited plan mode this session
+/// - `needs_plan_mode_exit_attachment`: one-time notification flag
+/// - `pre_plan_mode`: permission mode before entering plan mode
+#[derive(Debug, Clone)]
+pub struct PlanModeState {
+    /// Whether plan mode has been exited at least once this session.
+    pub has_exited_plan_mode: bool,
+    /// Whether a plan-mode-exit attachment notification is pending.
+    pub needs_plan_mode_exit_attachment: bool,
+    /// The permission mode that was active before entering plan mode.
+    /// Used to restore when exiting plan mode.
+    pub pre_plan_mode: Option<String>,
+}
+
+impl Default for PlanModeState {
+    fn default() -> Self {
+        Self {
+            has_exited_plan_mode: false,
+            needs_plan_mode_exit_attachment: false,
+            pre_plan_mode: None,
+        }
+    }
+}
+
+impl PlanModeState {
+    /// Handle a transition between permission modes.
+    ///
+    /// Matches Claude Code's `handlePlanModeTransition`:
+    /// When transitioning FROM plan mode to another mode,
+    /// set the exit attachment flag so the system can inject
+    /// a one-time notification about the plan.
+    pub fn handle_transition(&mut self, from_mode: &str, to_mode: &str) {
+        if from_mode == "plan" && to_mode != "plan" {
+            self.has_exited_plan_mode = true;
+            self.needs_plan_mode_exit_attachment = true;
+        }
+    }
+
+    /// Consume the exit attachment flag (returns true once, then false).
+    pub fn take_exit_attachment(&mut self) -> bool {
+        if self.needs_plan_mode_exit_attachment {
+            self.needs_plan_mode_exit_attachment = false;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// Thread-safe plan slug cache: session_id -> slug.
+///
+/// Matches Claude Code's `planSlugCache: Map<string, string>`.
+pub struct PlanSlugCache {
+    cache: Mutex<HashMap<String, String>>,
+}
+
+impl PlanSlugCache {
+    pub fn new() -> Self {
+        Self {
+            cache: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Get or generate a slug for the given session.
+    ///
+    /// If a slug already exists for this session, returns it.
+    /// Otherwise generates a new one, retrying up to 10 times
+    /// if the slug's plan file already exists on disk.
+    pub fn get_or_create(&self, session_id: &str, plans_dir: &Path) -> String {
+        let mut cache = self.cache.lock().unwrap();
+        if let Some(slug) = cache.get(session_id) {
+            return slug.clone();
+        }
+
+        // Generate a new slug, retrying if file already exists
+        let slug = {
+            let mut attempts = 0;
+            loop {
+                let candidate = generate_slug();
+                let path = plans_dir.join(format!("{candidate}.md"));
+                if !path.exists() || attempts >= 10 {
+                    break candidate;
+                }
+                attempts += 1;
+            }
+        };
+
+        cache.insert(session_id.to_string(), slug.clone());
+        slug
+    }
+
+    /// Set a specific slug for a session (used during resume).
+    pub fn set(&self, session_id: &str, slug: &str) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.insert(session_id.to_string(), slug.to_string());
+    }
+
+    /// Get the slug for a session without creating one.
+    pub fn get(&self, session_id: &str) -> Option<String> {
+        let cache = self.cache.lock().unwrap();
+        cache.get(session_id).cloned()
+    }
+
+    /// Clear the slug for a specific session.
+    pub fn clear(&self, session_id: &str) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.remove(session_id);
+    }
+
+    /// Clear all cached slugs (e.g., on /clear).
+    pub fn clear_all(&self) {
+        let mut cache = self.cache.lock().unwrap();
+        cache.clear();
+    }
+}
+
+impl Default for PlanSlugCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Resolve the plans directory.
+///
+/// Priority:
+/// 1. Custom directory from settings (relative to project root, validated)
+/// 2. `~/.cisco-code/plans/` (default)
+///
+/// Creates the directory if it doesn't exist.
+pub fn resolve_plans_directory(custom_dir: Option<&str>, project_root: Option<&Path>) -> PathBuf {
+    if let Some(custom) = custom_dir {
+        if let Some(root) = project_root {
+            let resolved = root.join(custom);
+            // Path traversal defense: ensure resolved path stays within project root
+            if let (Ok(canonical_root), Ok(canonical_resolved)) =
+                (root.canonicalize(), resolved.canonicalize().or_else(|_| {
+                    // Directory might not exist yet — create and try again
+                    let _ = std::fs::create_dir_all(&resolved);
+                    resolved.canonicalize()
+                }))
+            {
+                if canonical_resolved.starts_with(&canonical_root) {
+                    return canonical_resolved;
+                }
+            }
+            // Fall through to default if validation fails
+            tracing::warn!(
+                "Plans directory '{custom}' escapes project root, using default"
+            );
+        }
+    }
+
+    let default = dirs_home()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".cisco-code")
+        .join("plans");
+    let _ = std::fs::create_dir_all(&default);
+    default
+}
+
+/// Get the plan file path for a session.
+///
+/// - Main agent: `{plans_dir}/{slug}.md`
+/// - Subagent: `{plans_dir}/{slug}-agent-{agent_id}.md`
+pub fn plan_file_path(plans_dir: &Path, slug: &str, agent_id: Option<&str>) -> PathBuf {
+    match agent_id {
+        Some(id) => plans_dir.join(format!("{slug}-agent-{id}.md")),
+        None => plans_dir.join(format!("{slug}.md")),
+    }
+}
+
+/// Read a plan from disk, returning None if the file doesn't exist.
+pub fn read_plan(plans_dir: &Path, slug: &str, agent_id: Option<&str>) -> Option<String> {
+    let path = plan_file_path(plans_dir, slug, agent_id);
+    std::fs::read_to_string(&path).ok()
+}
+
+/// Write a plan to disk.
+pub fn write_plan(
+    plans_dir: &Path,
+    slug: &str,
+    content: &str,
+    agent_id: Option<&str>,
+) -> Result<PathBuf> {
+    let path = plan_file_path(plans_dir, slug, agent_id);
+    let _ = std::fs::create_dir_all(plans_dir);
+    std::fs::write(&path, content)?;
+    Ok(path)
+}
+
+fn dirs_home() -> Option<PathBuf> {
+    std::env::var("HOME").ok().map(PathBuf::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_slug_format() {
+        let slug = generate_slug();
+        let parts: Vec<&str> = slug.split('-').collect();
+        assert_eq!(parts.len(), 3, "slug should have 3 parts: {slug}");
+        assert!(ADJECTIVES.contains(&parts[0]), "bad adjective: {}", parts[0]);
+        assert!(NOUNS.contains(&parts[1]), "bad noun: {}", parts[1]);
+        assert!(VERBS.contains(&parts[2]), "bad verb: {}", parts[2]);
+    }
+
+    #[test]
+    fn test_generate_slug_unique() {
+        let slug1 = generate_slug();
+        let slug2 = generate_slug();
+        // With counter-based seed, consecutive calls should differ
+        assert_ne!(slug1, slug2);
+    }
+
+    #[test]
+    fn test_plan_slug_cache_get_or_create() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = PlanSlugCache::new();
+        let slug1 = cache.get_or_create("session-1", dir.path());
+        let slug2 = cache.get_or_create("session-1", dir.path());
+        assert_eq!(slug1, slug2, "same session should return same slug");
+
+        let slug3 = cache.get_or_create("session-2", dir.path());
+        assert_ne!(slug1, slug3, "different sessions should get different slugs");
+    }
+
+    #[test]
+    fn test_plan_slug_cache_set_and_get() {
+        let cache = PlanSlugCache::new();
+        assert!(cache.get("sess").is_none());
+        cache.set("sess", "custom-slug-here");
+        assert_eq!(cache.get("sess").unwrap(), "custom-slug-here");
+    }
+
+    #[test]
+    fn test_plan_slug_cache_clear() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = PlanSlugCache::new();
+        cache.get_or_create("sess", dir.path());
+        assert!(cache.get("sess").is_some());
+        cache.clear("sess");
+        assert!(cache.get("sess").is_none());
+    }
+
+    #[test]
+    fn test_plan_slug_cache_clear_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = PlanSlugCache::new();
+        cache.get_or_create("a", dir.path());
+        cache.get_or_create("b", dir.path());
+        cache.clear_all();
+        assert!(cache.get("a").is_none());
+        assert!(cache.get("b").is_none());
+    }
+
+    #[test]
+    fn test_plan_file_path_main_agent() {
+        let dir = PathBuf::from("/tmp/plans");
+        let path = plan_file_path(&dir, "bold-creek-forge", None);
+        assert_eq!(path, PathBuf::from("/tmp/plans/bold-creek-forge.md"));
+    }
+
+    #[test]
+    fn test_plan_file_path_subagent() {
+        let dir = PathBuf::from("/tmp/plans");
+        let path = plan_file_path(&dir, "bold-creek-forge", Some("sub-001"));
+        assert_eq!(
+            path,
+            PathBuf::from("/tmp/plans/bold-creek-forge-agent-sub-001.md")
+        );
+    }
+
+    #[test]
+    fn test_read_write_plan() {
+        let dir = tempfile::tempdir().unwrap();
+        let content = "## Plan\n\n1. Step one\n2. Step two\n";
+
+        let path = write_plan(dir.path(), "test-slug-here", content, None).unwrap();
+        assert!(path.exists());
+
+        let read_back = read_plan(dir.path(), "test-slug-here", None).unwrap();
+        assert_eq!(read_back, content);
+    }
+
+    #[test]
+    fn test_read_plan_nonexistent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(read_plan(dir.path(), "nonexistent-slug-here", None).is_none());
+    }
+
+    #[test]
+    fn test_resolve_plans_directory_default() {
+        let dir = resolve_plans_directory(None, None);
+        assert!(dir.to_string_lossy().contains("plans"));
+    }
+
+    #[test]
+    fn test_resolve_plans_directory_custom() {
+        let root = tempfile::tempdir().unwrap();
+        let plans_sub = root.path().join("my-plans");
+        std::fs::create_dir_all(&plans_sub).unwrap();
+
+        let dir = resolve_plans_directory(Some("my-plans"), Some(root.path()));
+        assert_eq!(dir.canonicalize().unwrap(), plans_sub.canonicalize().unwrap());
+    }
+
+    #[test]
+    fn test_plan_mode_state_default() {
+        let state = PlanModeState::default();
+        assert!(!state.has_exited_plan_mode);
+        assert!(!state.needs_plan_mode_exit_attachment);
+        assert!(state.pre_plan_mode.is_none());
+    }
+
+    #[test]
+    fn test_plan_mode_state_transition() {
+        let mut state = PlanModeState::default();
+        // Entering plan mode doesn't trigger exit
+        state.handle_transition("default", "plan");
+        assert!(!state.has_exited_plan_mode);
+
+        // Exiting plan mode sets the flags
+        state.handle_transition("plan", "default");
+        assert!(state.has_exited_plan_mode);
+        assert!(state.needs_plan_mode_exit_attachment);
+    }
+
+    #[test]
+    fn test_plan_mode_state_take_exit_attachment() {
+        let mut state = PlanModeState::default();
+        state.handle_transition("plan", "default");
+
+        // First take returns true
+        assert!(state.take_exit_attachment());
+        // Second take returns false
+        assert!(!state.take_exit_attachment());
+        // has_exited remains true
+        assert!(state.has_exited_plan_mode);
+    }
+
+    #[test]
+    fn test_slug_retry_on_collision() {
+        let dir = tempfile::tempdir().unwrap();
+        let cache = PlanSlugCache::new();
+
+        // Pre-create a bunch of slug files (won't match generated ones usually,
+        // but verifies the retry logic doesn't panic)
+        let slug = cache.get_or_create("retry-test", dir.path());
+        assert!(!slug.is_empty());
+    }
+}

--- a/crates/protocol/src/events.rs
+++ b/crates/protocol/src/events.rs
@@ -74,6 +74,25 @@ pub enum StreamEvent {
         message: String,
         recoverable: bool,
     },
+
+    /// Plan mode entered — agent is now in read-only planning mode.
+    PlanModeEnter,
+
+    /// Plan mode exited — agent has presented plan and restored previous mode.
+    PlanModeExit {
+        /// The plan content (markdown).
+        plan: Option<String>,
+        /// Path where the plan was saved.
+        plan_file_path: Option<String>,
+        /// The permission mode being restored.
+        restored_mode: String,
+    },
+
+    /// Plan updated/saved to disk during plan mode.
+    PlanUpdate {
+        /// Path where the plan was saved.
+        plan_file_path: String,
+    },
 }
 
 /// Tool-specific progress data.

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -8,6 +8,7 @@ cisco-code-protocol = { path = "../protocol" }
 cisco-code-api = { path = "../api" }
 cisco-code-tools = { path = "../tools" }
 cisco-code-sandbox = { path = "../sandbox" }
+cisco-code-planning = { path = "../planning" }
 async-trait.workspace = true
 rusqlite.workspace = true
 tokio.workspace = true

--- a/crates/runtime/src/config.rs
+++ b/crates/runtime/src/config.rs
@@ -31,7 +31,7 @@ pub struct RuntimeConfig {
     pub thinking: Option<ThinkingConfig>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PermissionMode {
     /// Ask for every tool use
     Default,
@@ -41,6 +41,35 @@ pub enum PermissionMode {
     BypassPermissions,
     /// Deny all tool use
     DenyAll,
+    /// Plan mode — read-only, no code changes allowed.
+    /// Matches Claude Code's plan mode: the agent focuses on research,
+    /// analysis, and planning. Only read-only tools are permitted.
+    Plan,
+}
+
+impl PermissionMode {
+    /// Convert to a string identifier (used for state transitions).
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Default => "default",
+            Self::AcceptReads => "accept_reads",
+            Self::BypassPermissions => "bypass",
+            Self::DenyAll => "deny_all",
+            Self::Plan => "plan",
+        }
+    }
+
+    /// Parse from a string identifier.
+    pub fn from_str_lossy(s: &str) -> Self {
+        match s {
+            "default" => Self::Default,
+            "accept_reads" | "accept-reads" => Self::AcceptReads,
+            "bypass" => Self::BypassPermissions,
+            "deny_all" | "deny-all" => Self::DenyAll,
+            "plan" => Self::Plan,
+            _ => Self::Default,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -155,12 +184,7 @@ impl RuntimeConfig {
 
         if let Some(ref perms) = partial.permissions {
             if let Some(ref mode) = perms.mode {
-                self.permission_mode = match mode.as_str() {
-                    "accept-reads" => PermissionMode::AcceptReads,
-                    "bypass" => PermissionMode::BypassPermissions,
-                    "deny-all" => PermissionMode::DenyAll,
-                    _ => PermissionMode::Default,
-                };
+                self.permission_mode = PermissionMode::from_str_lossy(mode);
             }
         }
 
@@ -279,7 +303,7 @@ mode = "os-native"
         assert_eq!(config.max_tokens, 2048);
         assert_eq!(config.max_turns, 50); // unchanged
         assert_eq!(config.max_budget_usd, Some(5.0));
-        assert!(matches!(config.permission_mode, PermissionMode::AcceptReads));
+        assert_eq!(config.permission_mode, PermissionMode::AcceptReads);
     }
 
     #[test]
@@ -341,5 +365,40 @@ mode = "os-native"
         config.apply_partial(&project_partial);
         assert_eq!(config.model, "user-model"); // not overridden
         assert_eq!(config.max_tokens, 8192); // overridden
+    }
+
+    #[test]
+    fn test_permission_mode_as_str() {
+        assert_eq!(PermissionMode::Default.as_str(), "default");
+        assert_eq!(PermissionMode::AcceptReads.as_str(), "accept_reads");
+        assert_eq!(PermissionMode::BypassPermissions.as_str(), "bypass");
+        assert_eq!(PermissionMode::DenyAll.as_str(), "deny_all");
+        assert_eq!(PermissionMode::Plan.as_str(), "plan");
+    }
+
+    #[test]
+    fn test_permission_mode_from_str_lossy() {
+        assert_eq!(PermissionMode::from_str_lossy("default"), PermissionMode::Default);
+        assert_eq!(PermissionMode::from_str_lossy("accept_reads"), PermissionMode::AcceptReads);
+        assert_eq!(PermissionMode::from_str_lossy("accept-reads"), PermissionMode::AcceptReads);
+        assert_eq!(PermissionMode::from_str_lossy("bypass"), PermissionMode::BypassPermissions);
+        assert_eq!(PermissionMode::from_str_lossy("deny_all"), PermissionMode::DenyAll);
+        assert_eq!(PermissionMode::from_str_lossy("deny-all"), PermissionMode::DenyAll);
+        assert_eq!(PermissionMode::from_str_lossy("plan"), PermissionMode::Plan);
+        assert_eq!(PermissionMode::from_str_lossy("unknown"), PermissionMode::Default);
+    }
+
+    #[test]
+    fn test_permission_mode_plan_in_config() {
+        let mut config = RuntimeConfig::default();
+        let partial = PartialConfig {
+            general: None,
+            permissions: Some(PermissionsSection {
+                mode: Some("plan".into()),
+            }),
+            sandbox: None,
+        };
+        config.apply_partial(&partial);
+        assert_eq!(config.permission_mode, PermissionMode::Plan);
     }
 }

--- a/crates/runtime/src/conversation.rs
+++ b/crates/runtime/src/conversation.rs
@@ -473,6 +473,15 @@ impl<P: Provider> ConversationRuntime<P> {
             file_operation: None,
             prompt: Some(user_input.to_string()),
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let effective_prompt = match self.hooks.run(&prompt_hook_input).await {
             HookResult::Suppress { message } => {
@@ -643,6 +652,15 @@ impl<P: Provider> ConversationRuntime<P> {
                         file_operation: None,
                         prompt: None,
                         summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                     };
 
                     let mut effective_input = tool_input.clone();
@@ -928,6 +946,15 @@ impl<P: Provider> ConversationRuntime<P> {
                         file_operation: None,
                         prompt: None,
                         summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                     };
                     let _ = self.hooks.run(&post_hook_input).await;
 
@@ -961,6 +988,15 @@ impl<P: Provider> ConversationRuntime<P> {
                             file_operation: Some(file_op.to_string()),
                             prompt: None,
                             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                         };
                         let _ = self.hooks.run(&file_hook_input).await;
                     }
@@ -1026,6 +1062,15 @@ impl<P: Provider> ConversationRuntime<P> {
                     file_operation: None,
                     prompt: None,
                     summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                 };
                 let _ = self.hooks.run(&stop_input).await;
                 early_exit = true;
@@ -1056,6 +1101,15 @@ impl<P: Provider> ConversationRuntime<P> {
                         file_operation: None,
                         prompt: None,
                         summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                     };
                     let _ = self.hooks.run(&stop_input).await;
                     early_exit = true;
@@ -1088,6 +1142,15 @@ impl<P: Provider> ConversationRuntime<P> {
                     file_operation: None,
                     prompt: None,
                     summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                 };
                 let _ = self.hooks.run(&compact_start).await;
 
@@ -1159,6 +1222,15 @@ impl<P: Provider> ConversationRuntime<P> {
                             file_operation: None,
                             prompt: None,
                             summary_tokens: Some(summary_tokens),
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
                         };
                         let _ = self.hooks.run(&compact_end).await;
                     }
@@ -1186,6 +1258,15 @@ impl<P: Provider> ConversationRuntime<P> {
                 file_operation: None,
                 prompt: None,
                 summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
             };
             let _ = self.hooks.run(&stop_input).await;
         }

--- a/crates/runtime/src/hooks.rs
+++ b/crates/runtime/src/hooks.rs
@@ -16,36 +16,82 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 /// A lifecycle event that can trigger hooks.
+///
+/// Matches Claude Code v2.1.88's 27 hook event types.
+/// Organized by lifecycle phase: session, turn, tool, file, agent, plan, system.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum HookEvent {
-    /// Before a tool is executed. Hook can modify input or block execution.
-    PreToolUse,
-    /// After a tool has executed. Informational only.
-    PostToolUse,
+    // ── Session lifecycle ──
     /// When a new session starts.
     SessionStart,
     /// When a session ends.
     SessionEnd,
+    /// When a session is resumed from persistence.
+    SessionResume,
+    /// When a session is paused/suspended.
+    SessionPause,
+
+    // ── Turn lifecycle ──
     /// Before sending a message to the LLM.
     PreMessage,
     /// After receiving a response from the LLM.
     PostMessage,
-    /// Fired when the agent is stopped (Ctrl+C, cancel, max turns, completed).
-    Stop,
-    /// Fired when a subagent completes or is cancelled.
-    SubagentStop,
-    /// Fired when a notification is about to be sent to the user.
-    Notification,
     /// Fired when the user submits a prompt, before it's processed.
     /// Hook can modify the prompt (stdout JSON with "prompt" key) or suppress it (exit 1).
     UserPromptSubmit,
+
+    // ── Tool lifecycle ──
+    /// Before a tool is executed. Hook can modify input or block execution.
+    PreToolUse,
+    /// After a tool has executed. Informational only.
+    PostToolUse,
+    /// When a tool execution fails (non-zero exit, timeout, error).
+    PostToolFailure,
+
+    // ── File events ──
     /// Fired after a file is created or modified by a tool (Write, Edit, ApplyPatch).
     FileChanged,
+    /// Fired when a file is deleted.
+    FileDeleted,
+
+    // ── Agent/subagent events ──
+    /// Fired when the agent is stopped (Ctrl+C, cancel, max turns, completed).
+    Stop,
+    /// Fired when a subagent is spawned.
+    SubagentStart,
+    /// Fired when a subagent completes or is cancelled.
+    SubagentStop,
+
+    // ── Plan mode events ──
+    /// Fired when entering plan mode.
+    PlanModeEnter,
+    /// Fired when exiting plan mode (plan approved/written).
+    PlanModeExit,
+    /// Fired when a plan is updated/saved.
+    PlanUpdate,
+
+    // ── Worktree events ──
+    /// Fired when a git worktree is created for isolation.
+    WorktreeCreate,
+    /// Fired when a git worktree is cleaned up.
+    WorktreeRemove,
+
+    // ── System events ──
+    /// Fired when a notification is about to be sent to the user.
+    Notification,
     /// Fired before context compaction begins.
     CompactionStart,
     /// Fired after context compaction completes.
     CompactionEnd,
+    /// Fired when a permission request is made.
+    PermissionRequest,
+    /// Fired when the model encounters a rate limit or error and retries.
+    Retry,
+    /// Fired when a hook itself fails (meta-event for observability).
+    HookError,
+    /// Fired when a cron task triggers.
+    CronTrigger,
 }
 
 /// A configured hook: an event trigger + shell command.
@@ -110,6 +156,33 @@ pub struct HookInput {
     /// Compaction summary tokens (for CompactionEnd events).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary_tokens: Option<u64>,
+    /// Plan content (for PlanModeExit/PlanUpdate events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_content: Option<String>,
+    /// Plan file path (for PlanModeExit/PlanUpdate events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_file_path: Option<String>,
+    /// Plan slug (for plan-related events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_slug: Option<String>,
+    /// Permission mode (for PlanModeEnter/PlanModeExit/PermissionRequest events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub permission_mode: Option<String>,
+    /// Previous permission mode (for PlanModeExit — the mode being restored).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub previous_mode: Option<String>,
+    /// Error message (for PostToolFailure/HookError/Retry events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_message: Option<String>,
+    /// Retry attempt number (for Retry events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_attempt: Option<u32>,
+    /// Worktree path (for WorktreeCreate/WorktreeRemove events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
+    /// Cron task ID (for CronTrigger events).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cron_task_id: Option<String>,
 }
 
 /// Result of running a hook.
@@ -454,6 +527,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -491,6 +573,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let result = runner.run(&input).await;
         assert!(matches!(result, HookResult::Continue));
@@ -520,6 +611,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let result = runner.run(&input).await;
         assert!(matches!(result, HookResult::Continue));
@@ -549,6 +649,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let result = runner.run(&input).await;
         assert!(matches!(result, HookResult::Suppress { .. }));
@@ -581,6 +690,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let result = runner.run(&input).await;
         assert!(matches!(result, HookResult::Continue));
@@ -610,6 +728,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let result = runner.run(&input).await;
         assert!(matches!(result, HookResult::Error { .. }));
@@ -682,6 +809,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -707,6 +843,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -735,6 +880,15 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -822,8 +976,116 @@ mod tests {
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let result = runner.run(&input).await;
         assert!(matches!(result, HookResult::Continue));
+    }
+
+    #[test]
+    fn test_plan_mode_event_serialization() {
+        let enter = HookEvent::PlanModeEnter;
+        assert_eq!(serde_json::to_string(&enter).unwrap(), "\"plan_mode_enter\"");
+
+        let exit = HookEvent::PlanModeExit;
+        assert_eq!(serde_json::to_string(&exit).unwrap(), "\"plan_mode_exit\"");
+
+        let update = HookEvent::PlanUpdate;
+        assert_eq!(serde_json::to_string(&update).unwrap(), "\"plan_update\"");
+    }
+
+    #[test]
+    fn test_plan_mode_event_deserialization() {
+        let enter: HookEvent = serde_json::from_str("\"plan_mode_enter\"").unwrap();
+        assert_eq!(enter, HookEvent::PlanModeEnter);
+
+        let exit: HookEvent = serde_json::from_str("\"plan_mode_exit\"").unwrap();
+        assert_eq!(exit, HookEvent::PlanModeExit);
+    }
+
+    #[test]
+    fn test_plan_mode_hook_input_serialization() {
+        let input = HookInput {
+            event: HookEvent::PlanModeExit,
+            session_id: "sess-plan".into(),
+            tool_name: None,
+            tool_input: None,
+            tool_result: None,
+            is_error: None,
+            subagent_id: None,
+            stop_reason: None,
+            notification: None,
+            file_path: None,
+            file_operation: None,
+            prompt: None,
+            summary_tokens: None,
+            plan_content: Some("## Plan\n1. Step one".into()),
+            plan_file_path: Some("/home/.cisco-code/plans/bold-creek-forge.md".into()),
+            plan_slug: Some("bold-creek-forge".into()),
+            permission_mode: Some("default".into()),
+            previous_mode: Some("plan".into()),
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
+        };
+
+        let json = serde_json::to_string(&input).unwrap();
+        assert!(json.contains("\"plan_mode_exit\""));
+        assert!(json.contains("bold-creek-forge"));
+        assert!(json.contains("Step one"));
+        assert!(!json.contains("error_message")); // skip_serializing_if
+        assert!(!json.contains("worktree_path")); // skip_serializing_if
+    }
+
+    #[test]
+    fn test_all_new_events_serialize_deserialize() {
+        let events = vec![
+            (HookEvent::SessionResume, "\"session_resume\""),
+            (HookEvent::SessionPause, "\"session_pause\""),
+            (HookEvent::PostToolFailure, "\"post_tool_failure\""),
+            (HookEvent::FileDeleted, "\"file_deleted\""),
+            (HookEvent::SubagentStart, "\"subagent_start\""),
+            (HookEvent::PlanModeEnter, "\"plan_mode_enter\""),
+            (HookEvent::PlanModeExit, "\"plan_mode_exit\""),
+            (HookEvent::PlanUpdate, "\"plan_update\""),
+            (HookEvent::WorktreeCreate, "\"worktree_create\""),
+            (HookEvent::WorktreeRemove, "\"worktree_remove\""),
+            (HookEvent::PermissionRequest, "\"permission_request\""),
+            (HookEvent::Retry, "\"retry\""),
+            (HookEvent::HookError, "\"hook_error\""),
+            (HookEvent::CronTrigger, "\"cron_trigger\""),
+        ];
+
+        for (event, expected_json) in events {
+            let serialized = serde_json::to_string(&event).unwrap();
+            assert_eq!(serialized, expected_json, "serialize {:?}", event);
+
+            let deserialized: HookEvent = serde_json::from_str(expected_json).unwrap();
+            assert_eq!(deserialized, event, "deserialize {expected_json}");
+        }
+    }
+
+    #[test]
+    fn test_hook_config_deserialize_plan_events() {
+        let config: HookConfig = serde_json::from_str(
+            r#"{"event": "plan_mode_enter", "command": "on-plan-enter.sh"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.event, HookEvent::PlanModeEnter);
+
+        let config: HookConfig = serde_json::from_str(
+            r#"{"event": "plan_mode_exit", "command": "on-plan-exit.sh"}"#,
+        )
+        .unwrap();
+        assert_eq!(config.event, HookEvent::PlanModeExit);
     }
 }

--- a/crates/runtime/src/notify.rs
+++ b/crates/runtime/src/notify.rs
@@ -150,6 +150,15 @@ impl Notifier {
                 file_operation: None,
                 prompt: None,
                 summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
             };
             match hooks.run(&hook_input).await {
                 HookResult::Suppress { message } => {

--- a/crates/runtime/src/permissions.rs
+++ b/crates/runtime/src/permissions.rs
@@ -421,6 +421,18 @@ impl PermissionEngine {
                     ),
                 },
             },
+
+            // Plan mode: only read-only tools are allowed. All writes/executions
+            // are denied. Matches Claude Code's plan mode behavior.
+            PermissionMode::Plan => match permission_level {
+                PermissionLevel::ReadOnly => PermissionDecision::Allow,
+                _ => PermissionDecision::Deny {
+                    reason: format!(
+                        "'{tool_name}' is not allowed in plan mode (read-only). \
+                         Exit plan mode first to make changes."
+                    ),
+                },
+            },
         }
     }
 

--- a/crates/runtime/src/prompt.rs
+++ b/crates/runtime/src/prompt.rs
@@ -105,6 +105,12 @@ pub struct PromptBuilder {
     skills_context: Option<String>,
     todo_content: Option<String>,
     mcp_instructions: Option<String>,
+    /// Active plan content (injected when a plan exists from a previous plan mode session).
+    plan_content: Option<String>,
+    /// Plan file path (for reference in prompts).
+    plan_file_path: Option<String>,
+    /// Whether we're currently in plan mode.
+    in_plan_mode: bool,
 }
 
 impl PromptBuilder {
@@ -119,6 +125,9 @@ impl PromptBuilder {
             skills_context: None,
             todo_content: None,
             mcp_instructions: None,
+            plan_content: None,
+            plan_file_path: None,
+            in_plan_mode: false,
         }
     }
 
@@ -159,6 +168,19 @@ impl PromptBuilder {
 
     pub fn with_mcp_instructions(mut self, instructions: impl Into<String>) -> Self {
         self.mcp_instructions = Some(instructions.into());
+        self
+    }
+
+    /// Set the active plan content (from a previous plan mode session).
+    pub fn with_plan(mut self, content: impl Into<String>, file_path: impl Into<String>) -> Self {
+        self.plan_content = Some(content.into());
+        self.plan_file_path = Some(file_path.into());
+        self
+    }
+
+    /// Mark that we're currently in plan mode.
+    pub fn in_plan_mode(mut self, active: bool) -> Self {
+        self.in_plan_mode = active;
         self
     }
 
@@ -219,7 +241,27 @@ impl PromptBuilder {
             sections.push(format!("# MCP Server Instructions\n\n{mcp}"));
         }
 
-        // 10. Current date
+        // 10. Plan context
+        if self.in_plan_mode {
+            sections.push(
+                "# Plan Mode Active\n\n\
+                 You are currently in **plan mode**. Focus on research, analysis, and planning.\n\
+                 DO NOT write or edit any code files. Only use read-only tools.\n\
+                 When your plan is ready, call `ExitPlanMode` with your plan to present it for approval."
+                    .to_string(),
+            );
+        }
+        if let Some(ref plan) = self.plan_content {
+            let mut plan_section = String::from("# Active Plan\n\n");
+            if let Some(ref path) = self.plan_file_path {
+                plan_section.push_str(&format!("Plan file: `{path}`\n\n"));
+            }
+            plan_section.push_str("Follow this plan. Mark steps as you complete them.\n\n");
+            plan_section.push_str(plan);
+            sections.push(plan_section);
+        }
+
+        // 11. Current date
         let date = chrono::Local::now().format("%Y-%m-%d").to_string();
         sections.push(format!("# Current Date\nToday is {date}."));
 

--- a/crates/runtime/src/subagent.rs
+++ b/crates/runtime/src/subagent.rs
@@ -244,6 +244,15 @@ async fn fire_subagent_stop(
             file_operation: None,
             prompt: None,
             summary_tokens: None,
+            plan_content: None,
+            plan_file_path: None,
+            plan_slug: None,
+            permission_mode: None,
+            previous_mode: None,
+            error_message: None,
+            retry_attempt: None,
+            worktree_path: None,
+            cron_task_id: None,
         };
         let _ = hooks.run(&stop_input).await;
     }

--- a/crates/server/src/streaming.rs
+++ b/crates/server/src/streaming.rs
@@ -30,6 +30,9 @@ pub fn stream_events(
             StreamEvent::PermissionRequest { .. } => "permission_request",
             StreamEvent::TurnEnd { .. } => "turn_end",
             StreamEvent::Error { .. } => "error",
+            StreamEvent::PlanModeEnter => "plan_mode_enter",
+            StreamEvent::PlanModeExit { .. } => "plan_mode_exit",
+            StreamEvent::PlanUpdate { .. } => "plan_update",
         };
 
         let data = serde_json::to_string(&event).unwrap_or_else(|_| "{}".into());

--- a/crates/tools/src/plan.rs
+++ b/crates/tools/src/plan.rs
@@ -1,8 +1,12 @@
 //! Plan mode tools — EnterPlanMode and ExitPlanMode.
 //!
-//! Matches Claude Code's plan mode: a mode where the agent focuses on
-//! planning and designing before implementation. No code changes
-//! are made in plan mode.
+//! Matches Claude Code v2.1.88's plan mode architecture:
+//! - EnterPlanMode: switches permission mode to Plan (read-only)
+//! - ExitPlanMode: writes plan to disk, restores previous permission mode
+//!
+//! These tools emit JSON action descriptors that the ConversationRuntime
+//! intercepts to manage plan mode state transitions. The runtime handles
+//! the actual permission mode changes and plan file I/O via PlanManager.
 
 use anyhow::Result;
 use cisco_code_protocol::{PermissionLevel, ToolResult};
@@ -11,6 +15,11 @@ use serde_json::json;
 use crate::{Tool, ToolContext};
 
 /// Enter plan mode — switch to planning/design focus.
+///
+/// Matches Claude Code's EnterPlanModeTool:
+/// - Empty input schema (no parameters needed)
+/// - Sets permission mode to 'plan' (read-only)
+/// - Returns instructions for the 5-phase planning workflow
 pub struct EnterPlanModeTool;
 
 #[async_trait::async_trait]
@@ -20,52 +29,9 @@ impl Tool for EnterPlanModeTool {
     }
 
     fn description(&self) -> &str {
-        "Enter plan mode to focus on designing an implementation plan. In plan mode, no code changes are made — only research, analysis, and planning."
-    }
-
-    fn input_schema(&self) -> serde_json::Value {
-        json!({
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string",
-                    "description": "Optional description of what to plan"
-                }
-            },
-            "required": []
-        })
-    }
-
-    async fn call(&self, input: serde_json::Value, _ctx: &ToolContext) -> Result<ToolResult> {
-        let description = input["description"].as_str();
-
-        let mut request = json!({
-            "action": "enter_plan_mode",
-        });
-
-        if let Some(desc) = description {
-            request["description"] = json!(desc);
-        }
-
-        Ok(ToolResult::success(serde_json::to_string_pretty(&request)?))
-    }
-
-    fn permission_level(&self) -> PermissionLevel {
-        PermissionLevel::ReadOnly
-    }
-}
-
-/// Exit plan mode — return to normal execution.
-pub struct ExitPlanModeTool;
-
-#[async_trait::async_trait]
-impl Tool for ExitPlanModeTool {
-    fn name(&self) -> &str {
-        "ExitPlanMode"
-    }
-
-    fn description(&self) -> &str {
-        "Exit plan mode and return to normal execution mode where code changes can be made."
+        "Switch to plan mode to design an approach before coding. In plan mode, \
+         you focus on research, analysis, and planning — no code changes are made. \
+         Only read-only tools (Read, Grep, Glob, WebSearch, WebFetch, Agent) are permitted."
     }
 
     fn input_schema(&self) -> serde_json::Value {
@@ -77,17 +43,125 @@ impl Tool for ExitPlanModeTool {
     }
 
     async fn call(&self, _input: serde_json::Value, _ctx: &ToolContext) -> Result<ToolResult> {
-        let request = json!({
-            "action": "exit_plan_mode",
+        // Emit an action descriptor for the runtime to intercept.
+        // The runtime handles the actual permission mode transition.
+        let action = json!({
+            "action": "enter_plan_mode",
+            "message": "Entered plan mode. You are now in read-only planning mode."
         });
 
-        Ok(ToolResult::success(serde_json::to_string_pretty(&request)?))
+        Ok(ToolResult::success(format!(
+            "{}\n\n{}",
+            serde_json::to_string_pretty(&action)?,
+            PLAN_MODE_INSTRUCTIONS
+        )))
     }
 
     fn permission_level(&self) -> PermissionLevel {
         PermissionLevel::ReadOnly
     }
+
+    fn is_concurrency_safe(&self) -> bool {
+        true
+    }
 }
+
+/// Exit plan mode — present plan for approval and start coding.
+///
+/// Matches Claude Code's ExitPlanModeV2Tool:
+/// - Reads plan from disk (written during plan mode)
+/// - Restores previous permission mode
+/// - Returns plan content for user approval
+pub struct ExitPlanModeTool;
+
+#[async_trait::async_trait]
+impl Tool for ExitPlanModeTool {
+    fn name(&self) -> &str {
+        "ExitPlanMode"
+    }
+
+    fn description(&self) -> &str {
+        "Present your implementation plan for approval and exit plan mode. \
+         This restores the previous permission mode so you can start coding. \
+         Call this after you've designed a thorough plan."
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "plan": {
+                    "type": "string",
+                    "description": "The implementation plan in markdown format. This will be saved to disk."
+                }
+            },
+            "required": []
+        })
+    }
+
+    async fn call(&self, input: serde_json::Value, _ctx: &ToolContext) -> Result<ToolResult> {
+        let plan = input["plan"].as_str().map(|s| s.to_string());
+
+        // Emit an action descriptor for the runtime to intercept.
+        // The runtime handles: saving plan to disk, restoring permission mode,
+        // firing PlanModeExit hook.
+        let mut action = json!({
+            "action": "exit_plan_mode",
+        });
+
+        if let Some(ref plan_content) = plan {
+            action["plan"] = json!(plan_content);
+        }
+
+        let message = if let Some(ref plan_content) = plan {
+            format!(
+                "{}\n\nPlan approved. The following plan has been saved:\n\n{}",
+                serde_json::to_string_pretty(&action)?,
+                plan_content
+            )
+        } else {
+            format!(
+                "{}\n\nPlan mode exited. You can proceed with implementation.",
+                serde_json::to_string_pretty(&action)?
+            )
+        };
+
+        Ok(ToolResult::success(message))
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        // ExitPlanMode needs to write the plan file, but the runtime handles
+        // the actual write. The tool itself is read-only from the permission
+        // engine's perspective.
+        PermissionLevel::ReadOnly
+    }
+
+    fn is_concurrency_safe(&self) -> bool {
+        true
+    }
+}
+
+/// Instructions displayed when entering plan mode.
+///
+/// Matches Claude Code's 5-phase planning workflow:
+const PLAN_MODE_INSTRUCTIONS: &str = "\
+DO NOT write or edit any files except the plan file. Follow this workflow:
+
+1. **Explore**: Thoroughly research the codebase to understand the relevant code, \
+   architecture, and patterns. Use Read, Grep, Glob, and Agent tools.
+
+2. **Identify patterns**: Find similar features or patterns in the codebase that \
+   you can follow. Understanding existing conventions is critical.
+
+3. **Consider approaches**: Think through multiple implementation approaches. \
+   Consider trade-offs, risks, and complexity.
+
+4. **Clarify**: If anything is ambiguous, use AskUserQuestion to get clarification \
+   before finalizing the plan.
+
+5. **Design**: Create a concrete, step-by-step implementation strategy. Include \
+   specific file paths, function names, and code snippets where helpful. \
+   When ready, call ExitPlanMode with your plan to present it for approval.";
 
 #[cfg(test)]
 mod tests {
@@ -105,29 +179,45 @@ mod tests {
     #[tokio::test]
     async fn test_enter_plan_mode() {
         let tool = EnterPlanModeTool;
+        let result = tool.call(json!({}), &ctx()).await.unwrap();
+        assert!(!result.is_error);
+        assert!(result.output.contains("enter_plan_mode"));
+        assert!(result.output.contains("Explore"));
+        assert!(result.output.contains("ExitPlanMode"));
+    }
+
+    #[tokio::test]
+    async fn test_enter_plan_mode_ignores_extra_input() {
+        let tool = EnterPlanModeTool;
         let result = tool
-            .call(json!({"description": "Complex refactoring"}), &ctx())
+            .call(json!({"extra": "ignored"}), &ctx())
             .await
             .unwrap();
         assert!(!result.is_error);
         assert!(result.output.contains("enter_plan_mode"));
-        assert!(result.output.contains("Complex refactoring"));
     }
 
     #[tokio::test]
-    async fn test_enter_plan_mode_no_reason() {
-        let tool = EnterPlanModeTool;
-        let result = tool.call(json!({}), &ctx()).await.unwrap();
+    async fn test_exit_plan_mode_with_plan() {
+        let tool = ExitPlanModeTool;
+        let plan = "## Plan\n\n1. Refactor auth module\n2. Add tests";
+        let result = tool
+            .call(json!({"plan": plan}), &ctx())
+            .await
+            .unwrap();
         assert!(!result.is_error);
-        assert!(result.output.contains("enter_plan_mode"));
+        assert!(result.output.contains("exit_plan_mode"));
+        assert!(result.output.contains("Refactor auth module"));
+        assert!(result.output.contains("Plan approved"));
     }
 
     #[tokio::test]
-    async fn test_exit_plan_mode() {
+    async fn test_exit_plan_mode_without_plan() {
         let tool = ExitPlanModeTool;
         let result = tool.call(json!({}), &ctx()).await.unwrap();
         assert!(!result.is_error);
         assert!(result.output.contains("exit_plan_mode"));
+        assert!(result.output.contains("proceed with implementation"));
     }
 
     #[test]
@@ -135,6 +225,9 @@ mod tests {
         let tool = EnterPlanModeTool;
         let schema = tool.input_schema();
         assert_eq!(schema["type"], "object");
+        // Empty properties — no parameters needed
+        let props = schema["properties"].as_object().unwrap();
+        assert!(props.is_empty());
     }
 
     #[test]
@@ -142,6 +235,7 @@ mod tests {
         let tool = ExitPlanModeTool;
         let schema = tool.input_schema();
         assert_eq!(schema["type"], "object");
+        assert!(schema["properties"].get("plan").is_some());
     }
 
     #[test]
@@ -151,8 +245,23 @@ mod tests {
     }
 
     #[test]
+    fn test_plan_mode_concurrency_safe() {
+        assert!(EnterPlanModeTool.is_concurrency_safe());
+        assert!(ExitPlanModeTool.is_concurrency_safe());
+    }
+
+    #[test]
     fn test_plan_mode_names() {
         assert_eq!(EnterPlanModeTool.name(), "EnterPlanMode");
         assert_eq!(ExitPlanModeTool.name(), "ExitPlanMode");
+    }
+
+    #[test]
+    fn test_plan_mode_instructions_content() {
+        assert!(PLAN_MODE_INSTRUCTIONS.contains("Explore"));
+        assert!(PLAN_MODE_INSTRUCTIONS.contains("patterns"));
+        assert!(PLAN_MODE_INSTRUCTIONS.contains("approaches"));
+        assert!(PLAN_MODE_INSTRUCTIONS.contains("Clarify"));
+        assert!(PLAN_MODE_INSTRUCTIONS.contains("Design"));
     }
 }


### PR DESCRIPTION
## Summary

- Implement full plan mode support across 6 crates, matching Claude Code v2.1.88's architecture
- Add `PermissionMode::Plan` (read-only mode that denies writes/executes), `PlanManager` with file-based plan storage using word slugs (`adjective-noun-verb`), and session resume/fork support
- Expand hook events from 13 to 27 lifecycle events (plan mode, worktree, permission, retry, cron triggers) with extended `HookInput` fields
- Add plan context injection into the prompt builder (`in_plan_mode`, `plan_content`, `plan_file_path`) and `PlanModeEnter/Exit/Update` stream events for SSE

## Changes

### New files
- `crates/planning/src/plan.rs` — Plan data model: `PlanSlugCache`, `PlanModeState`, slug generation, file I/O, path traversal defense
- `crates/planning/src/manager.rs` — `PlanManager`: slug lifecycle, plan read/write, resume/fork, enter/exit transitions

### Modified files (13)
- `crates/planning/Cargo.toml` + `lib.rs` — Rewired from placeholder to full implementation
- `crates/runtime/src/config.rs` — `PermissionMode::Plan` + `as_str()`/`from_str_lossy()` methods
- `crates/runtime/src/hooks.rs` — 27 hook events + plan/worktree/error HookInput fields
- `crates/runtime/src/permissions.rs` — Plan mode: allow ReadOnly, deny everything else
- `crates/runtime/src/prompt.rs` — Plan context injection in prompt builder
- `crates/tools/src/plan.rs` — Rewritten EnterPlanMode/ExitPlanMode matching Claude Code
- `crates/protocol/src/events.rs` — `PlanModeEnter/Exit/Update` stream events
- `crates/runtime/src/conversation.rs` + `notify.rs` + `subagent.rs` — Updated `HookInput` constructors
- `crates/server/src/streaming.rs` — Handle new `StreamEvent` variants
- `crates/runtime/Cargo.toml` — Added `cisco-code-planning` dependency

## Test plan

- [x] 29 planning crate tests pass (`cargo test -p cisco-code-planning`)
- [x] 12 plan tool tests pass (`cargo test -p cisco-code-tools -- plan`)
- [x] 91 hook/config/permission tests pass (`cargo test -p cisco-code-runtime -- hooks config permissions`)
- [x] Full workspace compiles with 0 errors (`cargo check --workspace`)
- [ ] Subagents writing additional integration tests (in progress)

🤖 Generated with [Claude Code](https://claude.com/claude-code)